### PR TITLE
Reanalyze and set line when stepping or running unvalidated code.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -157,6 +157,10 @@ $(document).ready(function(){
         if(!me.valid){
             try{
                 mipsAnalyze();
+                  mipsAnalyze(true);
+                  me.setLine(1);
+                  lastLineNoRun = null;
+                  setHighlights();
             } catch(e){
                 addToLog('error', e.message, 1);
             }
@@ -262,7 +266,10 @@ $(document).ready(function(){
         if(!me.valid){
             editor.save();
             me.setCode($("#editor").val());
-            me.valid = true;
+            mipsAnalyze(true);
+            me.setLine(1);
+            lastLineNoRun = null;
+            setHighlights();
         }
         running = true;
         var lineRanThisRun = 0;


### PR DESCRIPTION
This small change fixes a bug loading code by pasting it into the editor or using the URL params generated by WeMips. Currently in either of these situations the mipsAnalyze() and me.setLine() functions are not called before stepping or running, leading to the program not starting at line 1.