### PR TITLE
convert message to String in addToLog function

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -459,6 +459,7 @@ $(document).ready(function(){
         return MIPS.numberToBinaryString(num, 8);
     }
     function addToLog(type, message, line_no){
+        message = String(message);
         message = message.replace(/\n/g, "<br />");
         if(type == 'error') type = 'danger';
         if(line_no){


### PR DESCRIPTION
There was a bug when using syscall to output integers (code 1). The message sent to addToLog is an integer and needed to be converted to a string before being parsed.

![image](https://user-images.githubusercontent.com/18488647/201274386-8680e1d9-cc2e-4e5f-bd3b-1297cb963760.png)
![image](https://user-images.githubusercontent.com/18488647/201274458-9962483c-5405-448c-a487-5f134d98e475.png)
